### PR TITLE
Updated package and webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@ All notable changes to the "phpunit-test-workbench" extension will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2022-09-29
+## [0.1.0] - 2022-10-14
 - Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
-        "php-parser": "^3.1.0",
+        "php-parser": "^3.1.1",
         "stream-browserify": "^3.0.0",
         "timers-browserify": "^2.0.12",
         "util": "^0.12.4",
@@ -3458,9 +3458,9 @@
       }
     },
     "node_modules/php-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.0.tgz",
-      "integrity": "sha512-EwtoPSCqggAgTcPbV4YXsvUjYRQCZCxsQzxa7z8RX8rJ8bWAglMMi1tFNxdzwf5uNPFWFjHYhXA3REuWKzgMuw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.1.tgz",
+      "integrity": "sha512-HUxWIWpJoGhnSVzM6nPI1O2RePd7eJKzJoL3VZr6/KUUdcHKBex2Cp7p6pWOV1WxgKI/oYgRPMywwLCP789OYA=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -7057,9 +7057,9 @@
       "dev": true
     },
     "php-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.0.tgz",
-      "integrity": "sha512-EwtoPSCqggAgTcPbV4YXsvUjYRQCZCxsQzxa7z8RX8rJ8bWAglMMi1tFNxdzwf5uNPFWFjHYhXA3REuWKzgMuw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.1.tgz",
+      "integrity": "sha512-HUxWIWpJoGhnSVzM6nPI1O2RePd7eJKzJoL3VZr6/KUUdcHKBex2Cp7p6pWOV1WxgKI/oYgRPMywwLCP789OYA=="
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phpunit-test-workbench",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phpunit-test-workbench",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "vscode": "^1.71.0"
   },
   "categories": [
-    "Other"
+    "Testing"
   ],
   "icon": "docs/images/icon.png",
   "activationEvents": [
     "onLanguage:php",
     "workspaceContains:**/*.phpt"
   ],
-  "main": "./dist/extension",
+  "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
@@ -162,7 +162,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "child_process": "^1.0.2",
-    "php-parser": "^3.1.0",
+    "php-parser": "^3.1.1",
     "stream-browserify": "^3.0.0",
     "timers-browserify": "^2.0.12",
     "util": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/chiefmyron/phpunit-test-workbench"
   },
   "publisher": "chiefmyron",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.71.0"
   },

--- a/src/parser/TestFileParser.ts
+++ b/src/parser/TestFileParser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-/// <reference path="../../types/php-parser.d.ts" />
 import * as vscode from 'vscode';
 import * as xml2js from 'xml2js';
 import Engine from 'php-parser';
@@ -328,7 +326,7 @@ export class TestFileParser {
         // Parse test file contents
         let tree: any;
         try {
-            tree = this.phpParser.parseCode(testFileContents);
+            tree = this.phpParser.parseCode(testFileContents, testFileUri.fsPath);
         } catch (e) {
             this.logger.warn('An error occurred while parsing the test file! Error message: ' + e);
             return;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
-  target: 'webworker', // vscode extensions run in webworker context for VS Code web 📖 -> https://webpack.js.org/configuration/target/#target
+  target: 'node', // vscode extensions run in webworker context for VS Code web 📖 -> https://webpack.js.org/configuration/target/#target
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -19,8 +19,7 @@ const config = {
   },
   devtool: 'source-map',
   externals: {
-    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-    child_process: 'commonjs child_process'
+    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader


### PR DESCRIPTION
Updated webpack configuration to target 'node' rather than 'webworker'. As an interim fix, the 'dist' version of php-parser has been manually modified from:

```
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["PhpParser"] = factory();
	else
		root["PhpParser"] = factory();
})(self, () => {
return /******/ (() => { // webpackBootstrap
```

to

```
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["PhpParser"] = factory();
	else
		root["PhpParser"] = factory();
})(typeof self !== 'undefined' ? self : this, function() => {
return /******/ (() => { // webpackBootstrap
```