### PR TITLE
Launch tasks not referencing webpack build for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,9 @@
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
+				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "npm: webpack"
 		},
 		{
 			"name": "Extension Tests",
@@ -26,7 +26,7 @@
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
+				"${workspaceFolder}/dist/test/**/*.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
 		}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "onLanguage:php",
     "workspaceContains:**/*.phpt"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension",
   "contributes": {
     "commands": [
       {
@@ -130,15 +130,12 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run package",
+    "vscode:prepublish": "webpack --mode production",
     "webpack": "webpack --mode development",
     "webpack-dev": "webpack --mode development --watch",
-    "package": "webpack --mode production --devtool hidden-source-map",
-    "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js",
+    "package": "webpack --mode production --devtool hidden-source-map",
+    "lint": "eslint src --ext .ts,.tsx",
     "test-compile": "tsc -p ./"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated scripts in `package.json` to use webpack for all compile steps. Similarly, updated `launch.json` to use the new `webpack` script as the prelaunch build task.