### PR TITLE
Renaming a test class causes child methods to be "undetected" until full refresh of tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,7 +145,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Register event handlers
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration(e => dispatcher.handleChangedConfiguration(e)),
-        vscode.workspace.onDidChangeTextDocument(e => dispatcher.handleChangedTextDocument(e)),
+        vscode.workspace.onDidSaveTextDocument(e => dispatcher.handleSavedTextDocument(e)),
         vscode.workspace.onDidRenameFiles(e => dispatcher.handleRenamedFile(e)),
         vscode.workspace.onDidDeleteFiles(e => dispatcher.handleDeletedFile(e))
     );

--- a/src/loader/TestFileLoader.ts
+++ b/src/loader/TestFileLoader.ts
@@ -917,6 +917,12 @@ export class TestFileLoader {
             // Update label and definition to match latest details from the file
             item.label = this.setLabelIcon(definition.getType(), label);
             item.range = definition.getRange();
+
+            // If the parent for the method has changed (i.e. the test class has been renamed), update it now
+            if (parent && item.parent?.id !== parent.id) {
+                parent.children.add(item);
+            }
+
             this.testItemMap.set(item, definition);
             return item;
         }

--- a/src/ui/EventDispatcher.ts
+++ b/src/ui/EventDispatcher.ts
@@ -69,18 +69,17 @@ export class EventDispatcher {
     }
 
     /**
-     * If the text file being changed is relevant to the extension (i.e. either a test file, or a PHPUnit 
+     * If the text file being saved is relevant to the extension (i.e. either a test file, or a PHPUnit 
      * configuration file), this event will trigger the loader to reparse the file for changes / additions
      * to TestItems within the file. 
      * 
      * If the file is within the scope of an active continuous test run, this event will also trigger a new
      * test run.
      * 
-     * @param event vscode.TextDocumentChangeEvent
+     * @param document vscode.TextDocument
      */
-    public async handleChangedTextDocument(event: vscode.TextDocumentChangeEvent) {
+    public async handleSavedTextDocument(document: vscode.TextDocument) {
         // Only need to parse actual source code files (prevents parsing of URIs with git scheme, for example)
-        let document = event.document;
         if (document.uri.scheme !== 'file') {
             return;
         }


### PR DESCRIPTION
Fixes #96